### PR TITLE
feat(engines): add envsubst engine for env var substitution

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 
 ### Supported Engines
 
+- Envsubst
 - Go Templates (including [Sprig Functions](http://masterminds.github.io/sprig/))
 - Jinja
 - Handlebars

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22.0
 require (
 	github.com/CloudyKit/jet/v6 v6.2.0
 	github.com/Masterminds/sprig/v3 v3.2.3
+	github.com/a8m/envsubst v1.4.2
 	github.com/aymerick/raymond v2.0.2+incompatible
 	github.com/cbroglie/mustache v1.4.0
 	github.com/goreleaser/fileglob v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/Masterminds/semver/v3 v3.2.0 h1:3MEsd0SM6jqZojhjLWWeBY+Kcjy9i6MQAeY7Y
 github.com/Masterminds/semver/v3 v3.2.0/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/Masterminds/sprig/v3 v3.2.3 h1:eL2fZNezLomi0uOLqjQoN6BfsDD+fyLtgbJMAj9n6YA=
 github.com/Masterminds/sprig/v3 v3.2.3/go.mod h1:rXcFaZ2zZbLRJv/xSysmlgIM1u11eBaRMhvYXJNkGuM=
+github.com/a8m/envsubst v1.4.2 h1:4yWIHXOLEJHQEFd4UjrWDrYeYlV7ncFWJOCBRLOZHQg=
+github.com/a8m/envsubst v1.4.2/go.mod h1:MVUTQNGQ3tsjOOtKCNd+fl8RzhsXcDvvAEzkhGtlsbY=
 github.com/aymerick/raymond v2.0.2+incompatible h1:VEp3GpgdAnv9B2GFyTvqgcKvY+mfKMjPOA3SbKLtnU0=
 github.com/aymerick/raymond v2.0.2+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/caarlos0/testfs v0.4.4 h1:3PHvzHi5Lt+g332CiShwS8ogTgS3HjrmzZxCm6JCDr8=

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -128,6 +128,7 @@ func (a *App) run(cCtx *cli.Context) error {
 		cCtx.StringSlice("datasource"),
 		cCtx.StringSlice("data"),
 		cCtx.StringSlice("exclude"),
+		cCtx.String("engine"),
 	); err != nil {
 		if err := cli.ShowAppHelp(cCtx); err != nil {
 			return fmt.Errorf("show app help: %s", err)

--- a/internal/app/app_integration_test.go
+++ b/internal/app/app_integration_test.go
@@ -30,6 +30,7 @@ func TestIntegrationAllEngines(t *testing.T) {
 
 	// Define the input syntax for each engine
 	inputSyntax := map[string]string{
+		"envsubst":    "Hello, my name is ${Name}. I am ${Age} years old.",
 		"gotemplates": `Hello, my name is {{ .Name }}. I am {{ .Age }} years old.`,
 		"jinja":       `Hello, my name is {{ Name }}. I am {{ Age }} years old.`,
 		"handlebars":  `Hello, my name is {{ Name }}. I am {{ Age }} years old.`,

--- a/internal/app/app_integration_test.go
+++ b/internal/app/app_integration_test.go
@@ -32,10 +32,10 @@ func TestIntegrationAllEngines(t *testing.T) {
 	inputSyntax := map[string]string{
 		"envsubst":    "Hello, my name is ${Name}. I am ${Age} years old.",
 		"gotemplates": `Hello, my name is {{ .Name }}. I am {{ .Age }} years old.`,
-		"jinja":       `Hello, my name is {{ Name }}. I am {{ Age }} years old.`,
 		"handlebars":  `Hello, my name is {{ Name }}. I am {{ Age }} years old.`,
-		"mustache":    `Hello, my name is {{ Name }}. I am {{ Age }} years old.`,
 		"jet":         `Hello, my name is {{ Name }}. I am {{ Age }} years old.`,
+		"jinja":       `Hello, my name is {{ Name }}. I am {{ Age }} years old.`,
+		"mustache":    `Hello, my name is {{ Name }}. I am {{ Age }} years old.`,
 	}
 	require.Equal(t, len(enginesMap), len(inputSyntax), "all engines must be tested")
 

--- a/internal/app/parse.go
+++ b/internal/app/parse.go
@@ -15,10 +15,10 @@ import (
 var enginesMap = map[string]engines.Engine{
 	"envsubst":    &engines.EnvsubstEngine{},
 	"gotemplates": &engines.GoTemplatesEngine{},
-	"jinja":       &engines.JinjaEngine{},
 	"handlebars":  &engines.HandlebarsEngine{},
-	"mustache":    &engines.MustacheEngine{},
 	"jet":         &engines.JetEngine{},
+	"jinja":       &engines.JinjaEngine{},
+	"mustache":    &engines.MustacheEngine{},
 }
 
 func (a *App) parseDatasourceUrls(datasources []string) ([]*url.URL, error) {

--- a/internal/app/parse.go
+++ b/internal/app/parse.go
@@ -13,6 +13,7 @@ import (
 )
 
 var enginesMap = map[string]engines.Engine{
+	"envsubst":    &engines.EnvsubstEngine{},
 	"gotemplates": &engines.GoTemplatesEngine{},
 	"jinja":       &engines.JinjaEngine{},
 	"handlebars":  &engines.HandlebarsEngine{},

--- a/internal/app/validate.go
+++ b/internal/app/validate.go
@@ -22,6 +22,7 @@ func (a *App) validateFlags(
 	datasource []string,
 	data []string,
 	excluded []string,
+	engine string,
 ) error {
 	if len(inputString) == 0 && len(inputDir) == 0 && len(inputFile) == 0 {
 		return ErrNoInput
@@ -39,7 +40,7 @@ func (a *App) validateFlags(
 		return ErrInputFileAndDirConflict
 	}
 
-	if len(datasource) == 0 && len(data) == 0 {
+	if len(datasource) == 0 && len(data) == 0 && engine != "envsubst" {
 		return ErrDataRequired
 	}
 

--- a/internal/app/validate_test.go
+++ b/internal/app/validate_test.go
@@ -15,6 +15,7 @@ func TestValidateFlagsNoErrors(t *testing.T) {
 		[]string{"ds.yaml"},
 		nil,
 		nil,
+		"",
 	)
 	require.NoError(t, err)
 }
@@ -29,9 +30,25 @@ func TestValidateFlagsNoData(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		"",
 	)
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrDataRequired)
+}
+
+func TestValidateFlagsNoDataWithEnvsubstEngine(t *testing.T) {
+	app := NewApp()
+
+	err := app.validateFlags(
+		"",
+		"",
+		"input.txt",
+		nil,
+		nil,
+		nil,
+		"envsubst",
+	)
+	require.NoError(t, err)
 }
 
 func TestValidateFlagsNoInput(t *testing.T) {
@@ -43,6 +60,7 @@ func TestValidateFlagsNoInput(t *testing.T) {
 		[]string{"ds.yaml"},
 		nil,
 		nil,
+		"",
 	)
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrNoInput)
@@ -57,6 +75,7 @@ func TestValidateFlagsInputFileAndDirConflict(t *testing.T) {
 		[]string{"ds.yaml"},
 		nil,
 		nil,
+		"",
 	)
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrInputFileAndDirConflict)
@@ -71,6 +90,7 @@ func TestValidateFlagsInputStringAndFileConflict(t *testing.T) {
 		[]string{"ds.yaml"},
 		nil,
 		nil,
+		"",
 	)
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrInputStringAndFileConflict)
@@ -85,6 +105,7 @@ func TestValidateFlagsInputStringAndDirConflict(t *testing.T) {
 		[]string{"ds.yaml"},
 		nil,
 		nil,
+		"",
 	)
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrInputStringAndDirConflict)
@@ -99,6 +120,7 @@ func TestValidateFlagsInputFileAndExcludeConflict(t *testing.T) {
 		[]string{"ds.yaml"},
 		nil,
 		[]string{"exclude.txt"},
+		"",
 	)
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrInputFileAndExcludeConflict)
@@ -113,6 +135,7 @@ func TestValidateFlagsInputStringAndExcludeConflict(t *testing.T) {
 		[]string{"ds.yaml"},
 		nil,
 		[]string{"exclude.txt"},
+		"",
 	)
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrInputStringAndExcludeConflict)

--- a/internal/engines/envsubst.go
+++ b/internal/engines/envsubst.go
@@ -1,0 +1,63 @@
+package engines
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/a8m/envsubst"
+)
+
+type EnvsubstEngine struct{}
+
+func (e *EnvsubstEngine) RenderFile(file string, w io.Writer, data map[string]any) error {
+	buf, err := os.ReadFile(file)
+	if err != nil {
+		return err
+	}
+
+	err = envsubstRender(w, buf, data)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (e *EnvsubstEngine) Render(r io.Reader, w io.Writer, data map[string]any) error {
+	buf, err := io.ReadAll(r)
+	if err != nil {
+		return err
+	}
+
+	err = envsubstRender(w, buf, data)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func envsubstRender(w io.Writer, input []byte, data map[string]any) error {
+	// Set environment variables. This is necessary because envsubst does not allow directly passing data as environment variables.
+	for k, v := range data {
+		os.Setenv(k, fmt.Sprintf("%v", v))
+	}
+
+	tpl, err := envsubst.Bytes(input)
+	if err != nil {
+		return err
+	}
+
+	_, err = w.Write(tpl)
+	if err != nil {
+		return err
+	}
+
+	// Unset environment variables.
+	for k := range data {
+		os.Unsetenv(k)
+	}
+
+	return nil
+}

--- a/internal/engines/envsubst.go
+++ b/internal/engines/envsubst.go
@@ -11,17 +11,13 @@ import (
 type EnvsubstEngine struct{}
 
 func (e *EnvsubstEngine) RenderFile(file string, w io.Writer, data map[string]any) error {
-	buf, err := os.ReadFile(file)
+	f, err := os.Open(file)
 	if err != nil {
 		return err
 	}
+	defer f.Close()
 
-	err = envsubstRender(w, buf, data)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return e.Render(f, w, data)
 }
 
 func (e *EnvsubstEngine) Render(r io.Reader, w io.Writer, data map[string]any) error {
@@ -30,21 +26,12 @@ func (e *EnvsubstEngine) Render(r io.Reader, w io.Writer, data map[string]any) e
 		return err
 	}
 
-	err = envsubstRender(w, buf, data)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func envsubstRender(w io.Writer, input []byte, data map[string]any) error {
 	// Set environment variables. This is necessary because envsubst does not allow directly passing data as environment variables.
 	for k, v := range data {
 		os.Setenv(k, fmt.Sprintf("%v", v))
 	}
 
-	tpl, err := envsubst.Bytes(input)
+	tpl, err := envsubst.Bytes(buf)
 	if err != nil {
 		return err
 	}

--- a/internal/engines/envsubst_test.go
+++ b/internal/engines/envsubst_test.go
@@ -1,0 +1,58 @@
+package engines
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnvsubstRenderFile(t *testing.T) {
+	dir := t.TempDir()
+	file, err := os.CreateTemp(dir, "test.txt")
+	require.NoError(t, err)
+
+	_, err = file.WriteString("Hello, ${NAME}! You are ${AGE} years old.")
+	require.NoError(t, err)
+
+	engine := &EnvsubstEngine{}
+	writer := &bytes.Buffer{}
+	err = engine.RenderFile(file.Name(), writer, map[string]any{
+		"NAME": "John",
+		"AGE":  20,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "Hello, John! You are 20 years old.", writer.String())
+}
+
+func TestEnvsubstRenderFileAdvanced(t *testing.T) {
+	dir := t.TempDir()
+	file, err := os.CreateTemp(dir, "test.txt")
+	require.NoError(t, err)
+
+	_, err = file.WriteString("${GREETING=Hello}, James! Do you know the ${OTHER}?")
+	require.NoError(t, err)
+
+	engine := &EnvsubstEngine{}
+	writer := &bytes.Buffer{}
+	err = engine.RenderFile(file.Name(), writer, map[string]any{
+		"OTHER": []string{"a", "b", "c"},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "Hello, James! Do you know the [a b c]?", writer.String())
+}
+
+func TestEnvsubstRenderReader(t *testing.T) {
+	engine := &EnvsubstEngine{}
+	writer := &bytes.Buffer{}
+	err := engine.Render(bytes.NewBufferString("Hello, ${NAME}! You are ${AGE} years old."),
+		writer,
+		map[string]any{
+			"NAME": "John",
+			"AGE":  20,
+		})
+	require.NoError(t, err)
+	require.Equal(t, "Hello, John! You are 20 years old.", writer.String())
+}


### PR DESCRIPTION
done @orellazri please check

I'm not sure about this one though, if it's futile, I guess it is, as it won't really affect the env of the shell context that actually runs the program:
https://github.com/orellazri/renderkit/blob/be25ad5bd629d5c482dafb3d2c5dd5405088f389/internal/engines/envsubst.go#L57-L60